### PR TITLE
fix offline users in userlist

### DIFF
--- a/rooms.js
+++ b/rooms.js
@@ -1543,6 +1543,10 @@ let ChatRoom = (function () {
 			if (!this.users[i].named) {
 				continue;
 			}
+			if (!this.users[i].connected) {
+				delete this.users[i];
+				continue;
+			}
 			counter++;
 			buffer += ',' + this.users[i].getIdentity(this.id);
 		}


### PR DESCRIPTION
@TheFenderStory pls take a look at this. It should fix it since the user "class" (new User) is still stored in room.users. this just checks if they're offline, it will delete the user from the userlist. It's a temporary fix until we get to the bottom of it.
