### PR TITLE
Functional Urbandefine

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "dependencies": {
     "cloud-env": "0.1.1",
     "colors": "1.1.2",
+    "data.maybe": "^1.2.1",
+    "data.task": "^3.0.0",
     "elo-rank": "0.2.2",
     "es6-shim": "0.33.6",
     "float-ps": "^0.1.0",
@@ -17,6 +19,7 @@
     "node-static": "0.7.6",
     "origindb": "^2.1.0",
     "q": "^1.2.0",
+    "ramda": "^0.19.1",
     "request": "^2.58.0",
     "sockjs": "0.3.15",
     "sugar": "1.4.1",

--- a/urbandefine.js
+++ b/urbandefine.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const R = require('ramda');
+const Task = require('data.task');
+const Maybe = require('data.maybe');
+const request = require('request');
+
+const Just = Maybe.Just;
+const Nothing = Maybe.Nothing;
+const compose = R.compose;
+const head = R.head;
+const map = R.map;
+const prop = R.prop;
+const replace = R.replace;
+
+// safeHead :: [a] -> Maybe a
+const safeHead = function (xs) {
+	const firstElement = head(xs);
+	if (firstElement) return Just(firstElement);
+	return Nothing();
+};
+
+const Http = {
+	// get :: String -> Task Error JSON
+	get: function (url) {
+		return new Task(function (reject, resolve) {
+			return request(url, function (err, res, body) {
+				if (err || res.statusCode !== 200) return reject(err);
+				resolve(JSON.parse(body));
+			});
+		});
+	},
+};
+
+const baseUrl = 'http://www.urbandictionary.com/iphone/search/define?term={TARGET}';
+
+// makeUrl :: String -> String
+const makeUrl = function (t) {
+	return replace('{TARGET}', t, baseUrl);
+};
+
+// extractDefinition :: JSON -> String
+const extractDefinition = compose(map(prop('definition')), safeHead, prop('list'));
+
+// urbandefine :: String -> Task Error (Maybe String)
+const urbandefine = compose(map(extractDefinition), Http.get, makeUrl);
+
+module.exports = urbandefine;


### PR DESCRIPTION
I refactor urbandefine command to use the functional programming paradigm.

I have a bunch of const statements getting a require object property because node.js doesn't support es6 destructing which is `var {a, b, c} = require('alphabet');` yet.
