### PR TITLE
Limit tournament rounds of elimination

### DIFF
--- a/tournaments/index.js
+++ b/tournaments/index.js
@@ -873,6 +873,8 @@ let commands = {
 			if (params.length < 1) {
 				return this.sendReply("Usage: " + cmd + " <type> [, <comma-separated arguments>]");
 			}
+			if (params[2] > 6) params[2] = 6; // limit rounds of elimination to 6
+
 			let playerCap = parseInt(params.splice(1, 1));
 			let generator = createTournamentGenerator(params.shift(), params, this);
 			if (generator && tournament.setGenerator(generator, this)) {
@@ -1091,6 +1093,7 @@ CommandParser.commands.tournament = function (paramString, room, user) {
 		if (params.length < 2) {
 			return this.sendReply("Usage: " + cmd + " <format>, <type> [, <comma-separated arguments>]");
 		}
+		if (params[3] > 6) params[3] = 6; // limit rounds of elimination to 6
 
 		let tour = createTournament(room, params.shift(), params.shift(), params.shift(), Config.istournamentsrated, params, this);
 		if (tour) {


### PR DESCRIPTION
Currently, theres no limit whatsoever, and someone can make a tournament with 1*(10^308) rounds of elimination.  No need for this.  With this, when the amount of rounds of elimination specified is greater than 6, it automatically reverts to 6 rounds of elimination, preventing these absolutely insanely sized tournaments.  
