### PR TITLE
Refactor /toggleemotes

### DIFF
--- a/chat-plugins/emoticons.js
+++ b/chat-plugins/emoticons.js
@@ -143,7 +143,7 @@ function parseEmoticons(message, room, user, pm) {
 		room.add('|c|' + user.getIdentity().charAt(0) + user.name + '|' + parseWarlic(message));
 		return true;
 	}
-	if (typeof message !== 'string' || (!pm && room.disableEmoticons) && !~developers.indexOf(user.userid)) return false;
+	if (typeof message !== 'string' || (!pm && room.chatRoomData.disableEmoticons) && !~developers.indexOf(user.userid)) return false;
 
 	let match = false;
 	let len = emotesKeys.length;
@@ -247,13 +247,19 @@ exports.commands = {
 	toggleemote: 'toggleemoticons',
 	toggleemotes: 'toggleemoticons',
 	toggleemoticons: function (target, room, user) {
-		if (!this.can('declare', null, room)) return this.errorReply("Access denied.");
-		room.disableEmoticons = !room.disableEmoticons;
-		this.sendReply("Disallowing emoticons is set to " + room.disableEmoticons + " in this room.");
-		if (room.disableEmoticons) {
+		if (!this.can('declare', null, room)) return this.errorReply("/toggleemotes - Access denied.");
+		if (!room.disableEmoticons) {
+			room.disableEmoticons = true;
+			room.chatRoomData.disableEmoticons = true;
+			Rooms.global.writeChatRoomData();
 			this.add("|raw|<div class=\"broadcast-red\" style=\"border-radius: 5px;\"><b>Emoticons are disabled!</b><br />Emoticons will not work.</div>");
+			this.privateModCommand("(" + user.name + " has disabled emoticons in this room.)");
 		} else {
+			delete room.disableEmoticons;
+			delete room.chatRoomData.disableEmoticons;
+			Rooms.global.writeChatRoomData();
 			this.add("|raw|<div class=\"broadcast-blue\" style=\"border-radius: 5px;\"><b>Emoticons are enabled!</b><br />Emoticons will work now.</div>");
+			this.privateModCommand("(" + user.name + " has enabled emoticons in this room.)");
 		}
 	},
 	toggleemoticonshelp: ["/toggleemoticons - Toggle emoticons on or off."],


### PR DESCRIPTION
This makes /toggleemotes save to chatrooms.json, allowing toggleemotes to remain in its previous state after a server restart.  I've extensively tested these changes, and currently to my knowledge, the changes work flawlessly.  
